### PR TITLE
Specify the required version of Java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,12 @@ repositories {
     jcenter()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(15)
+    }
+}
+
 application {
     mainClass.set("com.pubmob.pos.PointOfSaleTerminal")
 }


### PR DESCRIPTION
Unfortunately, as far as I know, there is no easy and portable way to tell the IDE (e.g. IntelliJ Idea) which JDK to use when importing a gradle project.
One thing you could do though is to *at least* define the java language version, like I did in the `build.gradle`. 
See also https://docs.gradle.org/current/userguide/building_java_projects.html#introduction